### PR TITLE
1.21.8 skybox rendering

### DIFF
--- a/src/main/java/de/dafuqs/starryskies/client/sky/StarrySkyBox.java
+++ b/src/main/java/de/dafuqs/starryskies/client/sky/StarrySkyBox.java
@@ -2,7 +2,6 @@ package de.dafuqs.starryskies.client.sky;
 
 import com.mojang.blaze3d.buffers.*;
 import com.mojang.blaze3d.systems.*;
-import com.mojang.blaze3d.textures.*;
 import com.mojang.blaze3d.vertex.*;
 import de.dafuqs.starryskies.*;
 import de.dafuqs.starryskies.client.fix.*;
@@ -18,6 +17,8 @@ import net.minecraft.client.world.*;
 import net.minecraft.entity.*;
 import net.minecraft.entity.effect.*;
 import net.minecraft.util.*;
+import net.minecraft.util.math.*;
+import org.joml.*;
 
 import java.util.*;
 
@@ -57,7 +58,7 @@ public class StarrySkyBox implements DimensionRenderingRegistry.SkyRenderer {
 		}
 		// Create a proper frame pass so the starry sky would render
 		// Mimics vanilla logic
-		RenderSkyArgumentCapture capture = (RenderSkyArgumentCapture) context.worldRenderer();
+		RenderSkyArgumentCapture capture = context.worldRenderer();
 		FrameGraphBuilder frameGraphBuilder = capture.starrySkies$frameGraphBuilder();
 		DefaultFramebufferSet framebufferSet = capture.starrySkies$framebufferSet();
 		GpuBufferSlice fog = capture.starrySkies$fog();
@@ -94,52 +95,51 @@ public class StarrySkyBox implements DimensionRenderingRegistry.SkyRenderer {
 		};
 		for (var skyTexture : skyTextures) skyTexture.setFilter(false, false);
 		
-		//float[] prev = RenderSystem.getShaderColor();
-		
 		Camera camera = context.camera();
 		ClientWorld world = context.world();
 		float tickProgress = context.tickCounter().getTickProgress(false);
 		int color = world.getSkyColor(camera.getPos(), tickProgress);
-		/*RenderSystem.setShaderColor(
+		Vector4f colorVec = new Vector4f(
 				ColorHelper.getRedFloat(color),
 				ColorHelper.getGreenFloat(color),
 				ColorHelper.getBlueFloat(color),
-				ColorHelper.getAlphaFloat(color));*/
+				ColorHelper.getAlphaFloat(color)
+		);
+
+		// All defaults except for colorModulator (== colorVec)
+		GpuBufferSlice colorTransform = RenderSystem.getDynamicUniforms()
+				.write(RenderSystem.getModelViewMatrix(), colorVec, new Vector3f(), new Matrix4f(), 0.0F);
 		
 		// The number 36 comes from VertexFormat.DrawMode.QUADS.getIndexCount(24)
 		// the formula of which is vertexCount / 4 * 6, i.e. 6 indices per 4 vertices (1 quad)
 		GpuBuffer idxBuf = indexBuffer.getIndexBuffer(36);
 		Framebuffer framebuffer = client.getFramebuffer();
 		
-		GpuTextureView gpuTextureView = framebuffer.getColorAttachmentView();
-		GpuTextureView gpuTextureView2 = framebuffer.getDepthAttachmentView();
-		
-		RenderPass renderPass = RenderSystem.getDevice()
+		try (RenderPass renderPass = RenderSystem.getDevice()
 				.createCommandEncoder()
-				.createRenderPass(() -> "Cubemap", gpuTextureView, OptionalInt.empty(), gpuTextureView2, OptionalDouble.empty());
-		
-		// NOTE: using POSITION_TEX_COLOR_END_SKY because it uses BlendFunction.TRANSLUCENT
-		// The skybox texture looks washed out on POSITION_TEX_COLOR_CELESTIAL due to its BlendFunction.OVERLAY
-		renderPass.setPipeline(RenderPipelines.POSITION_TEX_COLOR_END_SKY);
-		renderPass.setIndexBuffer(idxBuf, indexBuffer.getIndexType());
-		renderPass.setVertexBuffer(0, this.skyVertexBuffer);
-			/*if (RenderSystem.SCISSOR_STATE.isEnabled()) {
-				renderPass.enableScissor(RenderSystem.SCISSOR_STATE);
-			}*/
-		// draw each quad (side) with a different texture
-		// 6 indices per quad, as per VertexFormat.DrawMode.QUADS.getIndexCount(4)
-		for (int i = 0; i < 6; ++i) {
-			renderPass.bindSampler("Sampler0", skyTextures[i].getGlTextureView());
-			renderPass.drawIndexed(6 * i, 6 * i, 36, 6); // TODO
+				.createRenderPass(() -> "Starry Skies skybox", framebuffer.getColorAttachmentView(), OptionalInt.empty(),
+						framebuffer.useDepthAttachment ? framebuffer.getDepthAttachmentView() : null, OptionalDouble.empty())) {
+			// NOTE: using POSITION_TEX_COLOR_END_SKY because it uses BlendFunction.TRANSLUCENT
+			// The skybox texture looks washed out on POSITION_TEX_COLOR_CELESTIAL due to its BlendFunction.OVERLAY
+			renderPass.setPipeline(RenderPipelines.POSITION_TEX_COLOR_END_SKY);
+			RenderSystem.bindDefaultUniforms(renderPass);
+			renderPass.setUniform("DynamicTransforms", colorTransform);
+			renderPass.setIndexBuffer(idxBuf, indexBuffer.getIndexType());
+			renderPass.setVertexBuffer(0, this.skyVertexBuffer);
+			// draw each quad (side) with a different texture
+			// 6 indices per quad, as per VertexFormat.DrawMode.QUADS.getIndexCount(4)
+			for (int i = 0; i < 6; ++i) {
+				renderPass.bindSampler("Sampler0", skyTextures[i].getGlTextureView());
+				renderPass.drawIndexed(0, 6 * i, 6, 1);
+			}
 		}
-		//RenderSystem.setShaderColor(prev[0], prev[1], prev[2], prev[3]);
-		
-		renderPass.close();
 	}
 	
 	// Write skybox vertices into skyVertexBuffer with the specified vertex color
 	private GpuBuffer uploadStarrySky() {
-		try (BufferAllocator bufferAllocator = new BufferAllocator(24 * VertexFormats.POSITION_TEXTURE_COLOR.getVertexSize())) {
+		// NOTE: method_72201 creates a BufferAllocator that has both size and capacity set to the argument
+		// doing this as default constructor has an "unlimited" max capacity, which will not catch overallocation
+		try (BufferAllocator bufferAllocator = BufferAllocator.method_72201(24 * VertexFormats.POSITION_TEXTURE_COLOR.getVertexSize())) {
 			BufferBuilder bufferBuilder = new BufferBuilder(bufferAllocator, VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
 			final int color = Colors.WHITE;
 			// NOTE: UV coords are left-to-right, up-to-down
@@ -187,12 +187,10 @@ public class StarrySkyBox implements DimensionRenderingRegistry.SkyRenderer {
 			bufferBuilder.vertex(100.0f, -100.0f, -100.0f).texture(1.0F, 0.0F).color(color);
 			bufferBuilder.vertex(-100.0f, -100.0f, -100.0f).texture(0.0F, 0.0F).color(color);
 			
-			BuiltBuffer builtBuffer = bufferBuilder.end();
-			GpuBuffer gpuBuffer = RenderSystem.getDevice().createBuffer(() -> "Top sky vertex buffer", 32, builtBuffer.getBuffer());
-			builtBuffer.close();
-			
-			bufferAllocator.close();
-			return gpuBuffer;
+			try (BuiltBuffer builtBuffer = bufferBuilder.end()) {
+				return RenderSystem.getDevice()
+						.createBuffer(() -> "StarrySkies sky vertex buffer", GpuBuffer.USAGE_VERTEX, builtBuffer.getBuffer());
+			}
 		}
 	}
 

--- a/src/main/java/de/dafuqs/starryskies/mixin/fix/WorldRendererMixinFix.java
+++ b/src/main/java/de/dafuqs/starryskies/mixin/fix/WorldRendererMixinFix.java
@@ -25,6 +25,7 @@ public class WorldRendererMixinFix implements RenderSkyArgumentCapture {
 	@Inject(at = @At(value = "HEAD"), method = "renderSky", order = 999 /* apply just before Fabric API */)
 	private void renderSky(FrameGraphBuilder frameGraphBuilder, Camera camera, float tickProgress, GpuBufferSlice fog, CallbackInfo ci) {
 		this.frameGraphBuilder = frameGraphBuilder;
+		this.fog = fog;
 	}
 	
 	@Override


### PR DESCRIPTION
Actually fixed the skybox rendering for 1.21.6 and beyond.
The only tangible difference is that Minecraft now uses the `DynamicTransforms` uniform instead of doing `RenderSystem` shader value calls.