### PR TITLE
26.2 skybox rendering

### DIFF
--- a/src/main/java/de/dafuqs/starryskies/client/StarrySkiesClient.java
+++ b/src/main/java/de/dafuqs/starryskies/client/StarrySkiesClient.java
@@ -2,13 +2,18 @@ package de.dafuqs.starryskies.client;
 
 import de.dafuqs.starryskies.*;
 import de.dafuqs.starryskies.client.sky.*;
+import de.dafuqs.starryskies.registries.StarryDimensionKeys;
 import net.fabricmc.api.*;
+import net.fabricmc.fabric.api.client.rendering.v1.RenderStateDataKey;
+import net.fabricmc.fabric.api.client.rendering.v1.level.LevelExtractionEvents;
 
 public class StarrySkiesClient implements ClientModInitializer {
 	public static StarrySkyBox SKYBOX;
+    public static RenderStateDataKey<Boolean> USE_SKYBOX;
 
 	@Override
 	public void onInitializeClient() {
+        LevelExtractionEvents.END_EXTRACTION.register(ctx -> ctx.levelState().setData(USE_SKYBOX, ctx.level() != null && StarryDimensionKeys.OVERWORLD_KEY.equals(ctx.level().dimension())));
         if (StarrySkies.CONFIG.rainbowSkybox)
             StarrySkyBoxTextures.INSTANCE.set("textures/skybox/rainbow_up.png", "textures/skybox/rainbow_down.png", "textures/skybox/rainbow_hori.png", "textures/skybox/rainbow_hori.png", "textures/skybox/rainbow_hori.png", "textures/skybox/rainbow_hori.png");
         else

--- a/src/main/java/de/dafuqs/starryskies/client/sky/StarrySkyBox.java
+++ b/src/main/java/de/dafuqs/starryskies/client/sky/StarrySkyBox.java
@@ -4,40 +4,38 @@ import com.mojang.blaze3d.*;
 import com.mojang.blaze3d.buffers.*;
 import com.mojang.blaze3d.pipeline.*;
 import com.mojang.blaze3d.systems.*;
-import com.mojang.blaze3d.textures.*;
 import com.mojang.blaze3d.vertex.*;
 import de.dafuqs.starryskies.client.*;
 import net.fabricmc.api.*;
 import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.texture.*;
-import net.minecraft.client.resources.model.sprite.*;
 import net.minecraft.util.*;
-import net.minecraft.world.level.*;
 
 import java.util.*;
 
-// Replaces vanilla SkyRenderer in Starry Skies Overworld
 @Environment(EnvType.CLIENT)
-public class StarrySkyBox extends SkyRenderer implements AutoCloseable {
+public class StarrySkyBox implements AutoCloseable {
 
 	private final GpuBuffer skyVertexBuffer;
-	private final RenderTarget renderTarget;
+	private final RenderTarget skyTarget;
+	private final RenderSystem.AutoStorageIndexBuffer indices = RenderSystem.getSequentialBuffer(PrimitiveTopology.QUADS);
 
 	public final AbstractTexture[] TEXTURES;
 
-	public StarrySkyBox(final TextureManager textureManager, final AtlasManager atlasManager, final RenderTarget renderTarget) {
-		super(textureManager, atlasManager, renderTarget);
+	public static final int INDICES_PER_FACE = PrimitiveTopology.QUADS.indexCount(4);
+	public static final int INDEXBUFFER_SIZE = INDICES_PER_FACE * 6;
 
-		TEXTURES = new AbstractTexture[]{
+	public StarrySkyBox(final TextureManager textureManager, final RenderTarget renderTarget) {
+		TEXTURES = new AbstractTexture[] {
 				textureManager.getTexture(StarrySkyBoxTextures.INSTANCE.NORTH),
 				textureManager.getTexture(StarrySkyBoxTextures.INSTANCE.SOUTH),
-				textureManager.getTexture(StarrySkyBoxTextures.INSTANCE.EAST),
-				textureManager.getTexture(StarrySkyBoxTextures.INSTANCE.WEST),
-				textureManager.getTexture(StarrySkyBoxTextures.INSTANCE.UP),
-				textureManager.getTexture(StarrySkyBoxTextures.INSTANCE.DOWN)
+				textureManager.getTexture(StarrySkyBoxTextures.INSTANCE.EAST ),
+				textureManager.getTexture(StarrySkyBoxTextures.INSTANCE.WEST ),
+				textureManager.getTexture(StarrySkyBoxTextures.INSTANCE.UP   ),
+				textureManager.getTexture(StarrySkyBoxTextures.INSTANCE.DOWN )
         };
-		this.renderTarget = renderTarget;
         skyVertexBuffer = uploadStarrySky();
+		skyTarget = renderTarget;
 	}
 
 	public void close() {
@@ -45,35 +43,28 @@ public class StarrySkyBox extends SkyRenderer implements AutoCloseable {
 	}
 	
 	// See SkyRenderer.renderEndSky() + CubeMap for inspiration
-	@Override
-	public void renderSkyDisc(final int skyColor) {
-		// The number 36 comes from VertexFormat.Mode.QUADS.getIndexCount(24)
-		// the formula of which is vertexCount / 4 * 6, i.e. 6 indices per 4 vertices (1 quad)
-		RenderSystem.AutoStorageIndexBuffer autoIndices = RenderSystem.getSequentialBuffer(PrimitiveTopology.QUADS);
-		GpuBuffer indexBuffer = autoIndices.getBuffer(36);
-		GpuTextureView colorTexture = this.renderTarget.getColorTextureView();
-		GpuTextureView depthTexture = this.renderTarget.getDepthTextureView();
-		GpuBufferSlice dynamicTransforms = RenderSystem.getDynamicUniforms().writeTransform(RenderSystem.getModelViewMatrixCopy(), ARGB.vector4fFromARGB32(skyColor));
-
-		try (RenderPass renderPass = RenderSystem.getDevice().createCommandEncoder().createRenderPass(() -> "Starry sky", colorTexture, Optional.empty(), depthTexture, OptionalDouble.empty())) {
+	public void renderStarrySky(int skyColor) {
+		// All defaults except for colorModulator (== sky color)
+		GpuBufferSlice colorTransform = RenderSystem.getDynamicUniforms()
+				.writeTransform(RenderSystem.getModelViewMatrixCopy(), ARGB.vector4fFromARGB32(skyColor));
+		GpuBuffer idxBuf = indices.getBuffer(INDEXBUFFER_SIZE);
+		
+		try (RenderPass renderPass = RenderSystem.getDevice()
+				.createCommandEncoder()
+				.createRenderPass(() -> "Starry Skies skybox", skyTarget.getColorTextureView(), Optional.empty(),
+						skyTarget.useDepth ? skyTarget.getDepthTextureView() : null, OptionalDouble.empty())) {
 			renderPass.setPipeline(RenderPipelines.END_SKY);
 			RenderSystem.bindDefaultUniforms(renderPass);
-			renderPass.setUniform("DynamicTransforms", dynamicTransforms);
-
-			renderPass.setIndexBuffer(indexBuffer, autoIndices.type());
+			renderPass.setUniform("DynamicTransforms", colorTransform);
+			renderPass.setIndexBuffer(idxBuf, indices.type());
 			renderPass.setVertexBuffer(0, this.skyVertexBuffer.slice());
 			// draw each quad (side) with a different texture
-			// 6 indices per quad, as per VertexFormat.Mode.QUADS.getIndexCount(4)
+			// 6 indices per quad, per PrimitiveTopology.QUADS.indexCount(4)
 			for (int i = 0; i < 6; ++i) {
 				renderPass.bindTexture("Sampler0", TEXTURES[i].getTextureView(), TEXTURES[i].getSampler());
-				renderPass.drawIndexed(36, 1, 0, 0, 0);
+				renderPass.drawIndexed(INDICES_PER_FACE, 1, INDICES_PER_FACE * i, 0, 0);
 			}
 		}
-	}
-
-	@Override
-	public void renderSunMoonAndStars(final PoseStack poseStack, final float sunAngle, final float moonAngle, final float starAngle, final MoonPhase moonPhase, final float rainBrightness, final float starBrightness) {
-
 	}
 	
 	// Write skybox vertices into skyVertexBuffer with the specified vertex color

--- a/src/main/java/de/dafuqs/starryskies/mixin/LevelRendererMixin.java
+++ b/src/main/java/de/dafuqs/starryskies/mixin/LevelRendererMixin.java
@@ -1,16 +1,17 @@
 package de.dafuqs.starryskies.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.buffers.*;
 import com.mojang.blaze3d.framegraph.*;
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import de.dafuqs.starryskies.client.*;
 import de.dafuqs.starryskies.client.sky.*;
-import de.dafuqs.starryskies.registries.*;
-import net.minecraft.client.*;
 import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.state.level.*;
-import net.minecraft.client.renderer.texture.*;
-import net.minecraft.client.resources.model.sprite.*;
-import net.minecraft.world.level.material.*;
-import org.jspecify.annotations.*;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.resources.model.sprite.AtlasManager;
+import org.objectweb.asm.*;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.*;
@@ -20,39 +21,27 @@ public class LevelRendererMixin {
 
     @Shadow
     @Final
+    private LevelTargetBundle targets;
+
+    @Shadow
+    @Final
     private LevelRenderState levelRenderState;
 
-    @Shadow
-    private @Nullable SkyRenderer skyRenderer;
+    @WrapOperation(method = "addSkyPass", at = @At(value = "NEW", target = "net/minecraft/client/renderer/SkyRenderer"))
+    private SkyRenderer reloadStarrySky(TextureManager textureManager, AtlasManager atlasManager, RenderTarget renderTarget, Operation<SkyRenderer> original) {
+        if (StarrySkiesClient.SKYBOX != null) StarrySkiesClient.SKYBOX.close();
+        StarrySkiesClient.SKYBOX = new StarrySkyBox(textureManager, renderTarget);
+        return original.call(textureManager, atlasManager, renderTarget);
+    }
 
-    @Shadow
-    @Final
-    private TextureManager textureManager;
-
-    @Shadow
-    @Final
-    private AtlasManager atlasManager;
-
-    @Shadow
-    @Final
-    private GameRenderer gameRenderer;
-
-    @Inject(method = "addSkyPass(Lcom/mojang/blaze3d/framegraph/FrameGraphBuilder;Lnet/minecraft/client/renderer/state/level/CameraRenderState;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;)V", at = @At(value = "HEAD"), cancellable = true)
+    @Inject(method = "addSkyPass", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/state/level/LevelRenderState;skyRenderState:Lnet/minecraft/client/renderer/state/level/SkyRenderState;", opcode = Opcodes.GETFIELD), cancellable = true)
     private void addStarrySky(FrameGraphBuilder frame, CameraRenderState cameraState, GpuBufferSlice skyFog, CallbackInfo ci) {
-        if (this.levelRenderState.shouldResetSkyRenderer || Minecraft.getInstance().level != null && StarryDimensionKeys.OVERWORLD_KEY.equals(Minecraft.getInstance().level.dimension())) {
-            FogType fogType = cameraState.fogType;
-            if (fogType != FogType.POWDER_SNOW && fogType != FogType.LAVA && !cameraState.entityRenderState.doesMobEffectBlockSky) {
-                if (this.levelRenderState.shouldResetSkyRenderer || this.skyRenderer == null) {
-                    if (this.skyRenderer != null) {
-                        this.skyRenderer.close();
-                    }
+        if (Boolean.FALSE.equals(this.levelRenderState.getData(StarrySkiesClient.USE_SKYBOX))) return;
+        ci.cancel();
 
-                    this.skyRenderer = new StarrySkyBox(this.textureManager, this.atlasManager, this.gameRenderer.mainRenderTarget());
-                    ci.cancel();
-                }
-            }
-        }
-
+        var pass = frame.addPass("starry_skies:sky");
+        this.targets.main = pass.readsAndWrites(this.targets.main);
+        pass.executes(() -> StarrySkiesClient.SKYBOX.renderStarrySky(this.levelRenderState.skyRenderState.skyColor));
     }
 
 }


### PR DESCRIPTION
I decided to restore the 26.1 skybox logic, as it requires a very tiny change to work on 26.2 anyway (namely some argument juggling for `renderPass.drawIndexed`)
Since `LevelRenderer` no longer contains the level that it renders, I've utilized the new `FabricRenderState` API to inject a simple skybox toggle flag into its level render state.